### PR TITLE
Use window history and remove commands

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -11,22 +11,6 @@
   "permissions": [
     "https://www.planet.com/*"
   ],
-  "commands": {
-    "show_next": {
-      "suggested_key": {
-        "default": "Ctrl+Right",
-        "mac": "Command+Right"
-      },
-      "description": "Show the next scene"
-    },
-    "show_previous": {
-      "suggested_key": {
-        "default": "Ctrl+Left",
-        "mac": "Command+Left"
-      },
-      "description": "Show the previous scene"
-    }
-  },
   "chrome_url_overrides": {
     "newtab": "index.html"
   },


### PR DESCRIPTION
This removes the Ctrl/Command + Arrow key handling for navigating through history.  Instead, the window history is used.  Clicking on the globe loads a new image.  Using back/forward buttons (or **⌘+[** and **⌘+]**) navigates through history.

Fixes #18.
