### PR TITLE
Use gallery.json and acquisition_date

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -31,7 +31,16 @@ function ready(err, world, gallery) {
   var scene = new Scene('#scene');
   var globe = new Globe('#map', world);
 
-  var player = new Player(gallery, scene, globe);
+  var entries = {};
+  var entry;
+  for (var i = 0, ii = gallery.length; i < ii; ++i) {
+    entry = gallery[i];
+    // assume link is stable identifier
+    entry.id = entry.link;
+    entries[entry.id] = entry;
+  }
+
+  var player = new Player(entries, scene, globe);
 
   d3.select('#map').on('click', function() {
     player.new();


### PR DESCRIPTION
We were still using the old atom feed that only had the publish date, but not the acquisition date. This updates the data source to be `gallery.json`, and uses it's `acquisition_date` field for the display date

cc @tschaub 
