### PR TITLE
Binary operators before line breaks

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -8,7 +8,10 @@
     "try",
     "catch"
   ],
-  "requireOperatorBeforeLineBreak": true,
+  "requireOperatorBeforeLineBreak": [
+    "?", "+", "-", "/", "*", "=", "==", "===",
+    "!=", "!==", ">", ">=", "<", "<="
+  ],
   "requireCamelCaseOrUpperCaseIdentifiers": "ignoreProperties",
   "maximumLineLength": {
     "value": 80,

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "autoprefixer": "^4.0.0",
     "browserify": "^6.3.2",
     "d3": "^3.4.13",
-    "jscs": "^1.7.3",
+    "jscs": "^1.8.1",
     "json": "^9.0.2",
     "less": "^2.0.0",
     "less-plugin-clean-css": "^1.2.0",

--- a/src/main.js
+++ b/src/main.js
@@ -71,8 +71,8 @@ Scene.prototype.show = function(data) {
   image.src = data.image;
 
   // TODO: rework scene markup
-  var title = data.title + ' (' + moment(data.acquisition_date).calendar()
-    + ')';
+  var title = data.title + ' (' + moment(data.acquisition_date).calendar() +
+      ')';
   d3.select('#image-title')
       .html('<a href="' + data.link + '">' + title + '</a>');
 };


### PR DESCRIPTION
Though automatic semicolon insertion doesn't kick in before binary operators, it's good practice to have line breaks follow operators (I make an exception for dot given the prevalence of jquery and d3 examples with dot after line break).

There is a jscs issue (see jscs-dev/node-jscs#733) keeping this rule from being enforced in all places, but it will take effect when the fix is released.
