### PR TITLE
Use full resolution image if available

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -64,11 +64,12 @@ function Scene(selector) {
  */
 Scene.prototype.show = function(data) {
   this.hide();
-  this.url = data.image;
+  var url = data.images.full || data.image;
+  this.url = url;
 
   var image = new Image();
-  image.onload = this._show.bind(this, data.image);
-  image.src = data.image;
+  image.onload = this._show.bind(this, url);
+  image.src = url;
 
   // TODO: rework scene markup
   var title = data.title + ' (' + moment(data.acquisition_date).calendar() +


### PR DESCRIPTION
The [`gallery.json`](https://www.planet.com/gallery.json) includes URLs for higher resolution images.  The extension now displays those images where available.

From where I sit, the load time is only marginally worth the wait.  I think it is worth looking into 1) preloading (this would only work for people who load multiple images from a single tab or would improve things if we had a deterministic load order) and 2) better compression.
