### PR TITLE
Minify sources for distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The development environemnt requires [Node](http://nodejs.org/) and [Make](http:
 
     make start
 
-From your chrome://extensions/ page, load the `./build/dist` directory as an unpacked extension.
+From your chrome://extensions/ page, load the `./build/dist` directory as an unpacked extension.  If you need to debug any of the sources, load the `./build/dev` directory as an unpacked extension instead.
 
 ## Publishing
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "queue-async": "^1.0.7",
     "semver": "^4.1.0",
     "topojson": "^1.6.18",
+    "uglify-js": "^2.4.15",
     "watchy": "0.5.4"
   }
 }


### PR DESCRIPTION
This separates the dev and dist build targets.  The dist JS source is 290K versus 1.1M for dev (largely due to source maps).  The installation archive is 25% smaller as a result.
